### PR TITLE
fix(connection): Fix signature of `send_and_receive`

### DIFF
--- a/src/connection/async_tokio.rs
+++ b/src/connection/async_tokio.rs
@@ -109,6 +109,12 @@ impl Connection {
         }
     }
 
+    /// Shorthand for calling [`send`] and [`receive`] after one another.
+    pub async fn send_and_receive<'de, A, B>(&mut self, data: &A) -> Result<B> where A: Serialize, B: Deserialize<'de> {
+        self.send(data).await?;
+        self.receive().await
+    }
+
     async fn _close(&mut self) {
         self.internal.close().await;
         self.closed = true;

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -118,7 +118,7 @@ impl Connection {
         }
     }
     /// Shorthand for calling [`send`](Self::send) and [`receive`](Self::receive) after one another.
-    pub fn send_and_receive<'de, A, B>(&mut self, data: &A) -> Result<Message<B>> where A: Serialize, B: Deserialize<'de> {
+    pub fn send_and_receive<'de, A, B>(&mut self, data: &A) -> Result<B> where A: Serialize, B: Deserialize<'de> {
         self.send(data)?;
         self.receive()
     }


### PR DESCRIPTION
Previously, the `send_and_receive` method of synchronous connections returned `Message<B>` - now it simply returns `B`, as it should (Message is the internal protocol of gipc).
Asynchronous connections also did not have the `send_and_receive` method - now they do.