### PR TITLE
feat: Add methods for checking if listeners/connections are closed

### DIFF
--- a/src/connection/async_tokio.rs
+++ b/src/connection/async_tokio.rs
@@ -22,8 +22,9 @@ use crate::message::Message;
 /// Listeners allow you to wait until new [`Connection`s](Connection) can be established.
 pub struct Listener {
     internal: Box<dyn ListenerImpl>,
-    closed: bool
+    closed: bool,
 }
+
 impl Listener {
     /// Creates a new listener based on a specified [`ListenerImpl`].
     /// Generally, you won't call this directly unless you're extending gipc.
@@ -54,19 +55,26 @@ impl Listener {
         self.closed = true; // we set it to closed either way
         self.internal.close().await
     }
+
+    /// Check if this listener is closed.
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
 }
+
 /// Connections represent a two-way bidirectional stream that you can send and receive messages through.
 pub struct Connection {
     internal: Box<dyn ConnectionImpl>,
-    closed: bool
+    closed: bool,
 }
+
 impl Connection {
     /// Creates a new connection based on a specified [`ConnectionImpl`].
     /// Generally, you won't call this directly unless you're extending gipc.
     pub const fn new(internal: Box<dyn ConnectionImpl>) -> Self {
         Self {
             internal,
-            closed: false
+            closed: false,
         }
     }
     /// Connects to a socket using a name based on `name`.
@@ -124,6 +132,11 @@ impl Connection {
         let _ = self._send::<()>(Message::ClosingConnection);
         self._close().await;
     }
+
+    /// Check if this connection is closed.
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
 }
 
 /// Listener implementation.
@@ -136,6 +149,7 @@ pub trait ListenerImpl: Send + Unpin {
     /// After this function is called, no more functions will be called from the implementation.
     async fn close(&mut self) -> Result<()>;
 }
+
 #[async_trait]
 impl ListenerImpl for LocalSocketListener {
     async fn accept(&mut self) -> Result<Connection> {
@@ -160,6 +174,7 @@ impl ConnectionImpl for LocalSocketStream {
         // Once again, do nothing
     }
 }
+
 impl From<LocalSocketStream> for Connection {
     fn from(value: LocalSocketStream) -> Self {
         Connection::new(Box::new(value))

--- a/src/connection/sync.rs
+++ b/src/connection/sync.rs
@@ -56,7 +56,13 @@ impl Listener {
         self.closed = true; // we set it to closed either way
         self.internal.close()
     }
+
+    /// Check if this listener is closed.
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
 }
+
 impl Drop for Listener {
     fn drop(&mut self) {
         let _ = self.close();
@@ -138,7 +144,13 @@ impl Connection {
         let _ = self._send::<()>(Message::ClosingConnection);
         self._close();
     }
+
+    /// Check if this connection is closed.
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
 }
+
 impl Drop for Connection {
     fn drop(&mut self) {
         self.close();
@@ -166,6 +178,7 @@ impl ListenerImpl for LocalSocketListener {
         Ok(())
     }
 }
+
 impl From<LocalSocketListener> for Listener {
     fn from(value: LocalSocketListener) -> Self {
         Self::new(Box::new(value))
@@ -185,6 +198,7 @@ impl ConnectionImpl for LocalSocketStream {
         let _ = self.flush();
     }
 }
+
 impl From<LocalSocketStream> for Connection {
     fn from(value: LocalSocketStream) -> Self {
         Connection::new(Box::new(value))


### PR DESCRIPTION
You could previously not check whether listeners or connections were closed. This PR adds the `is_closed` method to both listeners and connections.