### PR TITLE
Remove `mut` from Listener and Connection functions

### DIFF
--- a/examples/async-tokio/client.rs
+++ b/examples/async-tokio/client.rs
@@ -8,7 +8,7 @@ pub async fn main() {
     // Much like the synchronous connection, you connect using the `connect_to_socket` function.
     // It has the same parameters - the first one is the name of the socket, and the second is whether
     // the socket is global or not.
-    let mut connection = AsyncConnection::connect_to_socket(NAME, false)
+    let connection = AsyncConnection::connect_to_socket(NAME, false)
         .await
         .expect("Connection worked");
 

--- a/examples/async-tokio/listener.rs
+++ b/examples/async-tokio/listener.rs
@@ -8,7 +8,7 @@ pub async fn main() {
 
     // You begin by setting up a listener like so, much like the synchronous example
     //
-    let mut listener =
+    let listener =
         AsyncListener::listen_as_socket(NAME, false).expect("Couldn't listen! That's sad.");
 
     // However, here things change!
@@ -40,7 +40,7 @@ pub async fn main() {
 }
 
 // This is the code that handles the connections to the listener
-async fn handle_connection(mut connection: AsyncConnection) {
+async fn handle_connection(connection: AsyncConnection) {
     // This code is effectively the same as the synchronous example.
     // You send messages using the `send` method,
     connection

--- a/examples/sync/client.rs
+++ b/examples/sync/client.rs
@@ -8,7 +8,7 @@ pub fn main() {
     // Internally, gipc resolves the name to some location deterministically.
     // The second parameter here specifies whether or not to resolve the socket globally (i.e. when the listening process exists for the entire system).
     // In our case, it doesn't, so we set that parameter to false.
-    let mut connection =
+    let connection =
         Connection::connect_to_socket(NAME, false).expect("Connection should connect properly");
 
     // Once we've successfully connected, we can use its two main methods: `send` and `receive`.

--- a/examples/sync/listener.rs
+++ b/examples/sync/listener.rs
@@ -5,13 +5,13 @@ pub fn main() {
     println!("[listener] Listening to socket {}", NAME);
     // You begin by setting up a listener, much like you do a connection (see the client example).
     // The only difference is that you cannot begin sending and receiving messages yet.
-    let mut listener =
+    let listener =
         Listener::listen_as_socket(NAME, false).expect("Couldn't listen! That's sad.");
 
     // And then you just accept incoming connections!
     // This is a bad implementation, however - this can only handle one connection at a time!
     // See the async example for a better example on how a listener should work.
-    while let Ok(mut connection) = listener.accept() {
+    while let Ok(connection) = listener.accept() {
         // Once you've accepted the connection, everything works precisely like it does on
         // the client-side - this is because gipc uses the same type to represent a connection
         // from a client to a listener as it does for the listener to a client.


### PR DESCRIPTION
They don't particularly help with development and just add frustration IMO.